### PR TITLE
feat: Add custom backup prefix, improve flash safety UI, and fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Update build.gradle.kts with new version code and version name
         run: |
           # Update versionCode and versionName in build.gradle
-          sed -i "s/versionCode [0-9]\+/versionCode ${NEW_VERSION_CODE}/" app/build.gradle
-          sed -i "s/versionName \"[^\"]*\"/versionName \"${NEW_VERSION_NAME}\"/" app/build.gradle
+          sed -i "s/versionCode [0-9]\+/versionCode ${NEW_VERSION_CODE}/" app/build.gradle.kts
+          sed -i "s/versionName \"[^\"]*\"/versionName \"${NEW_VERSION_NAME}\"/" app/build.gradle.kts
 
       - name: Print Version
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Update build.gradle.kts with new version code and version name
         run: |
           # Update versionCode and versionName in build.gradle
-          sed -i "s/versionCode [0-9]\+/versionCode ${NEW_VERSION_CODE}/" app/build.gradle
-          sed -i "s/versionName \"[^\"]*\"/versionName \"${NEW_VERSION_NAME}\"/" app/build.gradle
+          sed -i "s/versionCode [0-9]\+/versionCode ${NEW_VERSION_CODE}/" app/build.gradle.kts
+          sed -i "s/versionName \"[^\"]*\"/versionName \"${NEW_VERSION_NAME}\"/" app/build.gradle.kts
 
       - name: Print Version
         run: |
@@ -117,7 +117,7 @@ jobs:
           git config user.email "github-actions@users.noreply.github.com"
           
           # Add modified build.gradle file
-          git add app/build.gradle
+          git add app/build.gradle.kts
           
           # Commit the changes
           git commit -m "Update versionName and versionCode to ${NEW_VERSION_NAME} and ${NEW_VERSION_CODE}"

--- a/app/src/main/java/com/github/capntrips/kernelflasher/ui/screens/slot/SlotFlashContent.kt
+++ b/app/src/main/java/com/github/capntrips/kernelflasher/ui/screens/slot/SlotFlashContent.kt
@@ -11,6 +11,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextButton
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.padding
@@ -66,6 +72,8 @@ fun ColumnScope.SlotFlashContent(
     val isFlashImage = currentRoute.endsWith("/flash/image")
     val isBackup = currentRoute.endsWith("/backup")
     val isBackupResult = currentRoute.endsWith("/backup/backup")
+    var showBackupDialog by remember { mutableStateOf(false) }
+    var customBackupName by remember { mutableStateOf("") }
     val isFlashAk3 = currentRoute.endsWith("/flash/ak3")
     val isImageFlashResult = currentRoute.endsWith("/flash/image/flash")
 
@@ -154,10 +162,7 @@ fun ColumnScope.SlotFlashContent(
                     .fillMaxWidth(),
                 shape = RoundedCornerShape(4.dp),
                 onClick = {
-                    viewModel.backup(context)
-                    navController.navigate("slot$slotSuffix/backup/backup") {
-                        popUpTo("slot$slotSuffix")
-                    }
+                    showBackupDialog = true
                 },
                 enabled = viewModel.backupPartitions.filter { it.value }.isNotEmpty()
             ) {
@@ -277,9 +282,15 @@ fun ColumnScope.SlotFlashContent(
             title = { Text("CAUTION!", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold) },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text("Are you Sure you want to flash this file?", fontWeight = FontWeight.Bold)
-                    Text("", fontWeight = FontWeight.Bold)
-                    Text("$filename", fontWeight = FontWeight.Bold)
+                    Text("Are you sure you want to flash this file?", fontWeight = FontWeight.Bold)
+                    
+                    Text("Source: $filename")
+                    
+                    if (viewModel.flashActionType == "flashImage" && viewModel.flashActionPartName != null) {
+                        Text("Destination Partition: ${viewModel.flashActionPartName}", fontWeight = FontWeight.Bold)
+                    } else if (viewModel.flashActionType == "flashAk3" || viewModel.flashActionType == "flashAk3_mkbootfs") {
+                        Text("Destination: AnyKernel3 (Auto-detect)", fontWeight = FontWeight.Bold)
+                    }
                 }
             },
             confirmButton = {
@@ -345,4 +356,35 @@ fun ColumnScope.SlotFlashContent(
             modifier = Modifier.padding(16.dp)
         )
     }
+    if (showBackupDialog) {
+        AlertDialog(
+            onDismissRequest = { showBackupDialog = false },
+            title = { Text("Custom Backup Name") },
+            text = {
+                OutlinedTextField(
+                    value = customBackupName,
+                    onValueChange = { customBackupName = it },
+                    label = { Text("Optional Prefix (e.g. Sultan)") },
+                    singleLine = true
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showBackupDialog = false
+                    viewModel.backup(context, customBackupName, slotSuffix) // <-- Add the suffix here!
+                    navController.navigate("slot$slotSuffix/backup/backup") {
+                        popUpTo("slot$slotSuffix") 
+                    }
+                }) {
+                    Text("Start Backup")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showBackupDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
 }
+        

--- a/app/src/main/java/com/github/capntrips/kernelflasher/ui/screens/slot/SlotFlashContent.kt
+++ b/app/src/main/java/com/github/capntrips/kernelflasher/ui/screens/slot/SlotFlashContent.kt
@@ -371,7 +371,7 @@ fun ColumnScope.SlotFlashContent(
             confirmButton = {
                 TextButton(onClick = {
                     showBackupDialog = false
-                    viewModel.backup(context, customBackupName, slotSuffix) // <-- Add the suffix here!
+                    viewModel.backup(context, customBackupName, slotSuffix)
                     navController.navigate("slot$slotSuffix/backup/backup") {
                         popUpTo("slot$slotSuffix") 
                     }

--- a/app/src/main/java/com/github/capntrips/kernelflasher/ui/screens/slot/SlotViewModel.kt
+++ b/app/src/main/java/com/github/capntrips/kernelflasher/ui/screens/slot/SlotViewModel.kt
@@ -78,6 +78,8 @@ class SlotViewModel(
         var bootImgInfo: BootImgInfo,
         var ramdiskInfo: RamdiskInfo,
     )
+    
+    
 
     private var _sha1: String? = null
     private val _slotInfo: MutableState<SlotInfo> = mutableStateOf(SlotInfo(BootSlotInfo(), BootImgInfo(), RamdiskInfo()))
@@ -494,7 +496,7 @@ class SlotViewModel(
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    fun backup(context: Context) {
+    fun backup(context: Context, customName: String = "", slotSuffix: String = "") {
         launch {
             _clearFlash()
 
@@ -503,7 +505,14 @@ class SlotViewModel(
                 _slotInfo.value.bootImgInfo.kernelVersion ?: System.getProperty("os.version")!!
             }
 
-            val now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd--HH-mm"))
+            val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd--HH-mm"))
+            // Sanitize the custom name to prevent file system errors
+            val safeName = customName.replace(Regex("[^a-zA-Z0-9_-]"), "_")
+            val prefix = if (safeName.isNotBlank()) "${safeName}_" else ""
+            
+            // Forge the final directory name
+            val now = "$prefix$timestamp$slotSuffix"
+
             val backupDir = createBackupDir(context, now)
             addMessage("Saving backup $now")
             val hashes = backupPartitions(context, backupDir)


### PR DESCRIPTION
## Overview
This PR introduces a few quality-of-life UI improvements for user safety and backup management, alongside a fix for the broken GitHub Actions build pipeline.

## Changes Included
* **Custom Backup Prefixes:** Added a Jetpack Compose dialog when initiating a backup. Users can now input an optional custom string (e.g., "Stock", "Inactive - all options"). The input is strictly regex-sanitized to prevent file system errors and is prepended to the standard timestamp/slot suffix.
* **Flash Safety UI:** Updated the flash confirmation dialog to explicitly state the **Source** and **Destination Partition**. This provides a critical safety check to prevent users from accidentally flashing an image to the wrong block.
* **CI Workflow Fix:** The recent migration to Kotlin DSL (`build.gradle.kts`) broke the GitHub Actions pipeline, as the `sed` commands were still looking for the old `app/build.gradle` file. Updated the `.github/workflows` YAML files to target the correct `.kts` extension, restoring automated CI builds.

## Testing
* Compiled locally and successfully built via GitHub Actions.
* Tested backup creation with custom strings containing spaces and special characters (regex successfully formats them to safe underscores).
* Verified the generated folder names parse correctly within the internal backup list UI.

*(Screenshots of the new UI below)*
<img width="796" height="1327" alt="Screenshot_20260330-155346" src="https://github.com/user-attachments/assets/364223fe-0b53-41f3-981e-b84170a438c5" />
<img width="759" height="1394" alt="Screenshot_20260330-155249" src="https://github.com/user-attachments/assets/54771a3b-904d-44d5-a017-f6ba92407f40" />
<img width="769" height="668" alt="Screenshot_20260330-160302" src="https://github.com/user-attachments/assets/aa1a5763-6a53-4cd9-81eb-8cb430fb78e2" />

